### PR TITLE
feat: add ResourceHierarchyLoader::findRecursive() and new CachedReso…

### DIFF
--- a/src/Loader/CachedResourceLoader.php
+++ b/src/Loader/CachedResourceLoader.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Resource\Loader;
+
+use Atoolo\Resource\Exception\InvalidResourceException;
+use Atoolo\Resource\Exception\ResourceNotFoundException;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceLoader;
+
+/**
+ * The CachedResourceLoader class is used to load resources
+ * from a given location and cache them for future use.
+ */
+class CachedResourceLoader implements ResourceLoader
+{
+    /**
+     * @var array<string, Resource>
+     */
+    private array $cache = [];
+    public function __construct(
+        private readonly ResourceLoader $resourceLoader,
+    ) {
+    }
+
+    /**
+     * @throws InvalidResourceException
+     * @throws ResourceNotFoundException
+     */
+    public function load(string $location): Resource
+    {
+        if (isset($this->cache[$location])) {
+            return $this->cache[$location];
+        }
+
+        $resource = $this->resourceLoader->load($location);
+        $this->cache[$location] = $resource;
+        return $resource;
+    }
+
+    public function exists(string $location): bool
+    {
+        if (isset($this->cache[$location])) {
+            return true;
+        }
+        return $this->resourceLoader->exists($location);
+    }
+}

--- a/src/Loader/SiteKitNavigationHierarchyLoader.php
+++ b/src/Loader/SiteKitNavigationHierarchyLoader.php
@@ -32,7 +32,7 @@ class SiteKitNavigationHierarchyLoader extends SiteKitResourceHierarchyLoader
         if ($parentLocation === null) {
             return $this->loadDefaultRootResource($resource);
         }
-        return $this->getResourceLoader()->load($parentLocation);
+        return $this->load($parentLocation);
     }
 
     /**
@@ -53,8 +53,8 @@ class SiteKitNavigationHierarchyLoader extends SiteKitResourceHierarchyLoader
             } else {
                 $location = $dir . '/index.php';
             }
-            if ($this->getResourceLoader()->exists($location)) {
-                $root = $this->getResourceLoader()->load($location);
+            if ($this->exists($location)) {
+                $root = $this->load($location);
                 if ($this->isRoot($root)) {
                     return $root;
                 }

--- a/src/Loader/SiteKitNavigationHierarchyLoader.php
+++ b/src/Loader/SiteKitNavigationHierarchyLoader.php
@@ -17,7 +17,7 @@ class SiteKitNavigationHierarchyLoader extends SiteKitResourceHierarchyLoader
         parent::__construct($resourceLoader, 'navigation');
     }
 
-    protected function isRoot(Resource $resource): bool
+    public function isRoot(Resource $resource): bool
     {
         return $resource->getData()->getBool('init.home');
     }

--- a/src/Loader/SiteKitResourceHierarchyLoader.php
+++ b/src/Loader/SiteKitResourceHierarchyLoader.php
@@ -83,6 +83,52 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
     }
 
     /**
+     * Walks the tree of resources starting from the given location and calls
+     * the given function for each resource. Returns the resource where the
+     * callable returns true.
+     *
+     * The callable function expects the following parameters:
+     * - array of Resource: the path to the current resource. Don't contains
+     *   the current resource.
+     * - Resource: the current resource
+     *
+     * The callable function should return true if the current resource is the
+     * one we are looking for.
+     *
+     * @param callable(Resource[], Resource): bool $fn
+     * @param Resource[] $parentPath
+     * @throws InvalidResourceException
+     * @throws ResourceNotFoundException
+     */
+    public function findRecursive(
+        string $location,
+        callable $fn,
+        array $parentPath = []
+    ): ?Resource {
+
+        $resource = $this->resourceLoader->load($location);
+
+        if ($fn($parentPath, $resource) === true) {
+            return $resource;
+        }
+
+        $childrenLocationList = $this->getChildrenLocationList($resource);
+        foreach ($childrenLocationList as $childLocation) {
+            $parentPathForChild = array_merge($parentPath, [$resource]);
+            $result = $this->findRecursive(
+                $childLocation,
+                $fn,
+                $parentPathForChild
+            );
+            if ($result !== null) {
+                return $result;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @throws InvalidResourceException if no primary parent can be found
      * @throws ResourceNotFoundException
      */

--- a/src/Loader/SiteKitResourceHierarchyLoader.php
+++ b/src/Loader/SiteKitResourceHierarchyLoader.php
@@ -88,8 +88,8 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
      * callable returns true.
      *
      * The callable function expects the following parameters:
-     * - array of Resource: the path to the current resource. Don't contains
-     *   the current resource.
+     * - array of Resource: the path to the current resource.
+     *   Does not contain the current resource
      * - Resource: the current resource
      *
      * The callable function should return true if the current resource is the

--- a/src/Loader/SiteKitResourceHierarchyLoader.php
+++ b/src/Loader/SiteKitResourceHierarchyLoader.php
@@ -96,14 +96,23 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
      * one we are looking for.
      *
      * @param callable(Resource[], Resource): bool $fn
-     * @param Resource[] $parentPath
      * @throws InvalidResourceException
      * @throws ResourceNotFoundException
      */
     public function findRecursive(
         string $location,
         callable $fn,
-        array $parentPath = []
+    ): ?Resource {
+        return $this->findRecursiveInternal($location, $fn, []);
+    }
+
+    /**
+     * @param Resource[] $parentPath
+     */
+    private function findRecursiveInternal(
+        string $location,
+        callable $fn,
+        array $parentPath
     ): ?Resource {
 
         $resource = $this->resourceLoader->load($location);
@@ -115,7 +124,7 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
         $childrenLocationList = $this->getChildrenLocationList($resource);
         foreach ($childrenLocationList as $childLocation) {
             $parentPathForChild = array_merge($parentPath, [$resource]);
-            $result = $this->findRecursive(
+            $result = $this->findRecursiveInternal(
                 $childLocation,
                 $fn,
                 $parentPathForChild

--- a/src/Loader/SiteKitResourceHierarchyLoader.php
+++ b/src/Loader/SiteKitResourceHierarchyLoader.php
@@ -22,6 +22,19 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
      * @throws InvalidResourceException
      * @throws ResourceNotFoundException
      */
+    public function load(string $location): Resource
+    {
+        return $this->resourceLoader->load($location);
+    }
+
+    public function exists(string $location): bool
+    {
+        return $this->resourceLoader->exists($location);
+    }
+    /**
+     * @throws InvalidResourceException
+     * @throws ResourceNotFoundException
+     */
     public function loadRoot(string $location): Resource
     {
         $resource = $this->resourceLoader->load($location);
@@ -121,11 +134,6 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
             return null;
         }
         return $this->resourceLoader->load($parentLocation);
-    }
-
-    public function getResourceLoader(): ResourceLoader
-    {
-        return $this->resourceLoader;
     }
 
     public function isRoot(Resource $resource): bool

--- a/src/Loader/SiteKitResourceHierarchyLoader.php
+++ b/src/Loader/SiteKitResourceHierarchyLoader.php
@@ -96,46 +96,6 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
     }
 
     /**
-     * Walks the tree of resources starting from the given location and calls
-     * the given function for each resource. Returns the resource where the
-     * callable returns true.
-     *
-     * The callable function expects the following parameter:
-     * - Resource: the current resource
-     *
-     * The callable function should return true if the current resource is the
-     * one we are looking for.
-     *
-     * @param callable(Resource): bool $fn
-     * @throws InvalidResourceException
-     * @throws ResourceNotFoundException
-     */
-    public function findRecursive(
-        string $location,
-        callable $fn,
-    ): ?Resource {
-
-        $resource = $this->resourceLoader->load($location);
-
-        if ($fn($resource) === true) {
-            return $resource;
-        }
-
-        $childrenLocationList = $this->getChildrenLocations($resource);
-        foreach ($childrenLocationList as $childLocation) {
-            $result = $this->findRecursive(
-                $childLocation,
-                $fn
-            );
-            if ($result !== null) {
-                return $result;
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * @throws InvalidResourceException if no primary parent can be found
      * @throws ResourceNotFoundException
      */

--- a/src/Loader/SiteKitResourceHierarchyLoader.php
+++ b/src/Loader/SiteKitResourceHierarchyLoader.php
@@ -36,7 +36,7 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
      * @throws InvalidResourceException
      * @throws ResourceNotFoundException
      */
-    public function loadParent(string $location): ?Resource
+    public function loadPrimaryParent(string $location): ?Resource
     {
         $resource = $this->resourceLoader->load($location);
         if ($this->isRoot($resource)) {
@@ -46,12 +46,25 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
     }
 
     /**
+     * @throws InvalidResourceException
+     * @throws ResourceNotFoundException
+     */
+    public function loadParent(string $location, string $parentId): ?Resource
+    {
+        $resource = $this->resourceLoader->load($location);
+        if ($this->isRoot($resource)) {
+            return null;
+        }
+        return $this->loadParentResource($resource, $parentId);
+    }
+
+    /**
      * @return Resource[]
      * @throws InvalidResourceException if an encountered Resource has no
      * parent but is not considered a root.
      * @throws ResourceNotFoundException
      */
-    public function loadPath(string $location): array
+    public function loadPrimaryPath(string $location): array
     {
         $resource = $this->resourceLoader->load($location);
         $path = [$resource];
@@ -74,7 +87,7 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
         $resource = $this->resourceLoader->load($location);
 
         $children = [];
-        $childrenLocationList = $this->getChildrenLocationList($resource);
+        $childrenLocationList = $this->getChildrenLocations($resource);
         foreach ($childrenLocationList as $childLocation) {
             $children[] = $this->resourceLoader->load($childLocation);
         }
@@ -108,7 +121,7 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
             return $resource;
         }
 
-        $childrenLocationList = $this->getChildrenLocationList($resource);
+        $childrenLocationList = $this->getChildrenLocations($resource);
         foreach ($childrenLocationList as $childLocation) {
             $result = $this->findRecursive(
                 $childLocation,
@@ -139,14 +152,29 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
         return $this->resourceLoader->load($parentLocation);
     }
 
-    protected function getResourceLoader(): ResourceLoader
+    protected function loadParentResource(
+        Resource $resource,
+        string $parentId
+    ): ?Resource {
+        $parentLocation = $this->getParentLocation($resource, $parentId);
+        if ($parentLocation === null) {
+            return null;
+        }
+        return $this->resourceLoader->load($parentLocation);
+    }
+
+    public function getResourceLoader(): ResourceLoader
     {
         return $this->resourceLoader;
     }
 
-    protected function isRoot(Resource $resource): bool
+    public function isRoot(Resource $resource): bool
     {
-        return $this->getPrimaryParentLocation($resource) === null;
+        $parentList = $resource->getData()->getAssociativeArray(
+            'base.trees.' . $this->treeName . '.parents'
+        );
+
+        return count($parentList) === 0;
     }
 
     /**
@@ -154,7 +182,7 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
      * @return string|null
      * @throws InvalidResourceException
      */
-    protected function getPrimaryParentLocation(Resource $resource): ?string
+    public function getPrimaryParentLocation(Resource $resource): ?string
     {
         $parentList = $resource->getData()->getAssociativeArray(
             'base.trees.' . $this->treeName . '.parents'
@@ -220,10 +248,41 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
         return $firstParent['url'];
     }
 
+    public function getParentLocation(
+        Resource $resource,
+        string $parentId
+    ): ?string {
+        $parentList = $resource->getData()->getAssociativeArray(
+            'base.trees.' . $this->treeName . '.parents'
+        );
+
+        if (
+            count($parentList) === 0
+        ) {
+            return null;
+        }
+
+        foreach ($parentList as $id => $parent) {
+            if (!is_array($parent)) {
+                throw new InvalidResourceException(
+                    $resource->getLocation(),
+                    'parent in ' .
+                    'base.trees.' . $this->treeName . '.parents ' .
+                    'not an array'
+                );
+            }
+            if ($parentId === (string)$id) {
+                return $parent['url'];
+            }
+        }
+
+        return null;
+    }
+
     /**
      * @return string[]
      */
-    protected function getChildrenLocationList(Resource $resource): array
+    public function getChildrenLocations(Resource $resource): array
     {
         $childrenList = $resource->getData()->getAssociativeArray(
             'base.trees.' . $this->treeName . '.children'

--- a/src/Loader/SiteKitResourceHierarchyLoader.php
+++ b/src/Loader/SiteKitResourceHierarchyLoader.php
@@ -87,15 +87,13 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
      * the given function for each resource. Returns the resource where the
      * callable returns true.
      *
-     * The callable function expects the following parameters:
-     * - array of Resource: the path to the current resource.
-     *   Does not contain the current resource
+     * The callable function expects the following parameter:
      * - Resource: the current resource
      *
      * The callable function should return true if the current resource is the
      * one we are looking for.
      *
-     * @param callable(Resource[], Resource): bool $fn
+     * @param callable(Resource): bool $fn
      * @throws InvalidResourceException
      * @throws ResourceNotFoundException
      */
@@ -103,31 +101,18 @@ class SiteKitResourceHierarchyLoader implements ResourceHierarchyLoader
         string $location,
         callable $fn,
     ): ?Resource {
-        return $this->findRecursiveInternal($location, $fn, []);
-    }
-
-    /**
-     * @param Resource[] $parentPath
-     */
-    private function findRecursiveInternal(
-        string $location,
-        callable $fn,
-        array $parentPath
-    ): ?Resource {
 
         $resource = $this->resourceLoader->load($location);
 
-        if ($fn($parentPath, $resource) === true) {
+        if ($fn($resource) === true) {
             return $resource;
         }
 
         $childrenLocationList = $this->getChildrenLocationList($resource);
         foreach ($childrenLocationList as $childLocation) {
-            $parentPathForChild = array_merge($parentPath, [$resource]);
-            $result = $this->findRecursiveInternal(
+            $result = $this->findRecursive(
                 $childLocation,
-                $fn,
-                $parentPathForChild
+                $fn
             );
             if ($result !== null) {
                 return $result;

--- a/src/ResourceHierarchyFinder.php
+++ b/src/ResourceHierarchyFinder.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Resource;
+
+use Atoolo\Resource\Exception\InvalidResourceException;
+use Atoolo\Resource\Exception\ResourceNotFoundException;
+
+class ResourceHierarchyFinder
+{
+    public function __construct(
+        private readonly ResourceHierarchyLoader $loader
+    ) {
+    }
+
+    /**
+     * Walks the tree of resources starting from the given resource and calls
+     * the given function for each resource. Returns the resource where the
+     * callable returns true.
+     *
+     * The callable function expects the following parameter:
+     * - Resource: the current resource
+     *
+     * The callable function should return true if the current resource is the
+     * one we are looking for.
+     *
+     * @param callable(Resource): bool $fn
+     * @throws InvalidResourceException
+     * @throws ResourceNotFoundException
+     */
+    public function findFirst(Resource|string $base, callable $fn): ?Resource
+    {
+
+        $walker = new ResourceHierarchyWalker($this->loader);
+
+        $walker->init($base);
+
+        $current = $walker->getCurrent();
+
+        if ($fn($current) === true) {
+            return $current;
+        }
+        while ($current = $walker->next()) {
+            if ($fn($current) === true) {
+                return $current;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ResourceHierarchyLoader.php
+++ b/src/ResourceHierarchyLoader.php
@@ -23,23 +23,23 @@ interface ResourceHierarchyLoader
     public function loadRoot(string $location): Resource;
 
     /**
-     * Determines the parent resource via the parent links contained in the
-     * resource data.
+     * Determines the primary parent resource via the parent links
+     * contained in the resource data.
      * @throws InvalidResourceException
      * @throws ResourceNotFoundException
      */
-    public function loadParent(string $location): ?Resource;
+    public function loadPrimaryParent(string $location): ?Resource;
 
     /**
-     * Determines the path to the root resource via the parent links contained
-     * in the resource data.
+     * Determines the path to the root resource via the primary parent links
+     * contained in the resource data.
      * The array contains the resources starting with the root resource. The
      * last element of the array is the resource of the passed `$location`
      * @return Resource[]
      * @throws InvalidResourceException
      * @throws ResourceNotFoundException
      */
-    public function loadPath(string $location): array;
+    public function loadPrimaryPath(string $location): array;
 
     /**
      * Determines the children resources via the children links contained in the
@@ -51,22 +51,39 @@ interface ResourceHierarchyLoader
     public function loadChildren(string $location): array;
 
     /**
-     * Walks the tree of resources starting from the given location and calls
-     * the given function for each resource. Returns the resource where the
-     * callable returns true.
+     * Indicates whether the passed resource is a root resource.
      *
-     * The callable function expects the following parameters:
-     * - Resource: the current resource
-     *
-     * The callable function should return true if the current resource is the
-     * one we are looking for.
-     *
-     * @param callable(Resource): bool $fn
-     * @throws InvalidResourceException
-     * @throws ResourceNotFoundException
+     * @param Resource $resource
+     * @return bool
      */
-    public function findRecursive(
-        string $location,
-        callable $fn
-    ): ?Resource;
+    public function isRoot(Resource $resource): bool;
+
+    /**
+     * Determines the children locations via the children links contained in the
+     * resource data.
+     *
+     * @return string[]
+     */
+    public function getChildrenLocations(Resource $resource): array;
+
+    /**
+     * Determines the primary parent location via the parent links contained in
+     * the resource data.
+     */
+    public function getPrimaryParentLocation(Resource $resource): ?string;
+
+    /**
+     * Determines the secondary parent location via the parent links contained
+     * in the resource data. A secondary parent is identified by the passed
+     * `$parentId`.
+     */
+    public function getParentLocation(
+        Resource $resource,
+        string $parentId
+    ): ?string;
+
+    /**
+     * Returns the `ResourceLoader` instance used to load resources.
+     */
+    public function getResourceLoader(): ResourceLoader;
 }

--- a/src/ResourceHierarchyLoader.php
+++ b/src/ResourceHierarchyLoader.php
@@ -49,4 +49,28 @@ interface ResourceHierarchyLoader
      * @throws ResourceNotFoundException
      */
     public function loadChildren(string $location): array;
+
+    /**
+     * Walks the tree of resources starting from the given location and calls
+     * the given function for each resource. Returns the resource where the
+     * callable returns true.
+     *
+     * The callable function expects the following parameters:
+     * - array of Resource: the path to the current resource. Don't contains
+     *   the current resource.
+     * - Resource: the current resource
+     *
+     * The callable function should return true if the current resource is the
+     * one we are looking for.
+     *
+     * @param callable(Resource[], Resource): bool $fn
+     * @param Resource[] $parentPath
+     * @throws InvalidResourceException
+     * @throws ResourceNotFoundException
+     */
+    public function findRecursive(
+        string $location,
+        callable $fn,
+        array $parentPath = []
+    ): ?Resource;
 }

--- a/src/ResourceHierarchyLoader.php
+++ b/src/ResourceHierarchyLoader.php
@@ -70,7 +70,6 @@ interface ResourceHierarchyLoader
      */
     public function findRecursive(
         string $location,
-        callable $fn,
-        array $parentPath = []
+        callable $fn
     ): ?Resource;
 }

--- a/src/ResourceHierarchyLoader.php
+++ b/src/ResourceHierarchyLoader.php
@@ -56,15 +56,12 @@ interface ResourceHierarchyLoader
      * callable returns true.
      *
      * The callable function expects the following parameters:
-     * - array of Resource: the path to the current resource. Don't contains
-     *   the current resource.
      * - Resource: the current resource
      *
      * The callable function should return true if the current resource is the
      * one we are looking for.
      *
-     * @param callable(Resource[], Resource): bool $fn
-     * @param Resource[] $parentPath
+     * @param callable(Resource): bool $fn
      * @throws InvalidResourceException
      * @throws ResourceNotFoundException
      */

--- a/src/ResourceHierarchyLoader.php
+++ b/src/ResourceHierarchyLoader.php
@@ -12,7 +12,7 @@ use Atoolo\Resource\Exception\ResourceNotFoundException;
  * resources or nodes whose hierarchical structure is defined in the resources.
  * For example, the navigation tree.
  */
-interface ResourceHierarchyLoader
+interface ResourceHierarchyLoader extends ResourceLoader
 {
     /**
      * Determines the root resource via the parent links contained in the
@@ -81,9 +81,4 @@ interface ResourceHierarchyLoader
         Resource $resource,
         string $parentId
     ): ?string;
-
-    /**
-     * Returns the `ResourceLoader` instance used to load resources.
-     */
-    public function getResourceLoader(): ResourceLoader;
 }

--- a/src/ResourceHierarchyWalker.php
+++ b/src/ResourceHierarchyWalker.php
@@ -6,6 +6,29 @@ namespace Atoolo\Resource;
 
 use LogicException;
 
+/**
+ * The `ResourceHierarchyWalker` class is used to traverse a hierarchy of
+ * resources.
+ *
+ * The walker needs a base resource to start with. This can be set with
+ * `init()`.
+ *
+ * The walker can then be moved up and down in the hierarchy
+ * with the help of methods like
+ * - `down()`
+ * - `child()`
+ * - `up()`
+ * - `nextSibling()`
+ * - `previousSibling()`
+ * - `next()`
+ *
+ * With these methods, the walker can only move below the base resource.
+ * To move above the base resource, the methods `primaryParent()`
+ * and `parent()` can be used.
+ *
+ * The walker can also be used to traverse the entire hierarchy
+ * with the help of the `walk()` method.
+ */
 class ResourceHierarchyWalker
 {
     private ?Resource $current = null;

--- a/src/ResourceHierarchyWalker.php
+++ b/src/ResourceHierarchyWalker.php
@@ -1,0 +1,412 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Resource;
+
+use LogicException;
+
+class ResourceHierarchyWalker
+{
+    private ?Resource $current = null;
+
+    /**
+     * Contains the children and all parent children
+     *  of the levels that have been traversed up to this point.
+     *
+     * @var array<array<string>>
+     */
+    private array $childrenStack = [];
+
+    /**
+     * Points to the children for all children lists of
+     * $childrenStack`. $childrenStackPointer[0] indicates the
+     * current position of `$childrenStack[0]`.
+     *
+     * @var array<int>
+     */
+    private array $childrenStackPointer = [];
+
+    /**
+     * @var Resource[]
+     */
+    private array $parentPath = [];
+
+    public function __construct(
+        private readonly ResourceHierarchyLoader $hierarchyLoader,
+    ) {
+    }
+
+    /**
+     * Defines the resource that the walker should initially use.
+     * It is important to first set an initial resource so that
+     * the walker can work.
+     *
+     * If the walker has already worked, it is reset.
+     *
+     * @param Resource|string $base The resource to be used initially.
+     *  If `$base` is a string it is assumed that it is a location and
+     *  the resource is loaded.
+     */
+    public function init(Resource|string $base): void
+    {
+        if (is_string($base)) {
+            $base = $this->load($base);
+        }
+        $this->current = $base;
+        $this->childrenStack = [];
+        $this->childrenStackPointer = [];
+        $this->parentPath = [];
+    }
+
+    /**
+     * There can be more than one higher-level resource in the hierarchy of
+     * a resource. One of these higher-level resources is always defined
+     * as primary. This method can be used to set the walker to the primary
+     * parent resource.
+     *
+     * Internally, `init()` is also called here with the determined parent.
+     * So that the walker is also reset if necessary.
+     *
+     * @return Resource|null Returns null if the current resource is
+     *  a root resource.
+     * @throws LogicException If no current resource is set.
+     */
+    public function primaryParent(): ?Resource
+    {
+        if ($this->current === null) {
+            throw new LogicException('No current resource set');
+        }
+
+        if ($this->hierarchyLoader->isRoot($this->current)) {
+            return null;
+        }
+
+        $primaryParentLocation = $this->hierarchyLoader
+            ->getPrimaryParentLocation($this->current);
+        if ($primaryParentLocation === null) {
+            return null;
+        }
+
+        $this->init($this->load(
+            $primaryParentLocation
+        ));
+
+        return $this->getCurrent();
+    }
+
+    /**
+     * There can be more than one parent resource in the hierarchy of a
+     * resource.
+     * This method can be used to set the walker to a specific parent
+     * resource.
+     *
+     * Internally, `init()` is also called here with the determined parent.
+     * So that the walker is also reset if necessary.
+     *
+     * @return Resource|null Returns null if the current resource is
+     * a root resource or the parent could not be determined.
+     * @throws LogicException If no current resource is set.
+     */
+    public function parent(string $parentId): ?Resource
+    {
+        if ($this->current === null) {
+            throw new LogicException('No current resource set');
+        }
+
+        if ($this->hierarchyLoader->isRoot($this->current)) {
+            return null;
+        }
+
+        $secondaryParentLocation = $this->hierarchyLoader
+            ->getParentLocation($this->current, $parentId);
+        if ($secondaryParentLocation === null) {
+            return null;
+        }
+
+        $this->init($this->load(
+            $secondaryParentLocation
+        ));
+
+        return $this->getCurrent();
+    }
+
+    /**
+     * The resource where the Walker is currently positioned.
+     * @throws LogicException If no current resource is set.
+     */
+    public function getCurrent(): Resource
+    {
+        if ($this->current === null) {
+            throw new LogicException('No current resource set');
+        }
+        return $this->current;
+    }
+
+    /**
+     * The level in which the walker is currently located.
+     * Based on the resource that was initially used.
+     */
+    public function getLevel(): int
+    {
+        return count($this->parentPath);
+    }
+
+    /**
+     * The path the walker has traveled up to the current element.
+     * Based on the resource that was initially used.
+     * The initial resource is the first, the current resource the
+     * last element of the path.
+     *
+     * @return Resource[]
+     */
+    public function getPath(): array
+    {
+        if ($this->current === null) {
+            return [];
+        }
+
+        $path = $this->parentPath;
+        $path[] = $this->current;
+        return $path;
+    }
+
+    /**
+     * Walk to the next sibling. Please note that this does not work for
+     * the initial resource that was set with `init()`, as the parent
+     * resource is not known. This case can be solved with the help of
+     * `primaryParent()` and `secondaryParent()`.
+     *
+     * ```
+     * $walker->init($base);
+     * $walker->primaryParent();
+     * $walker->child($base->getId());
+     * $walker->nextSibling();
+     * ```
+     *
+     * @return Resource|null Returns null if there are no more siblings.
+     */
+    public function nextSibling(): ?Resource
+    {
+        if (empty($this->childrenStack)) {
+            return null;
+        }
+
+        $topStackIndex = count($this->childrenStack) - 1;
+        $children = $this->childrenStack[$topStackIndex];
+        $pointer = $this->childrenStackPointer[$topStackIndex] + 1;
+
+        if ($pointer >= count($children)) {
+            return null;
+        }
+
+        $childLocation = $children[$pointer];
+        $child = $this->load($childLocation);
+
+        $this->childrenStackPointer[$topStackIndex] = $pointer;
+        $this->current = $child;
+        return $child;
+    }
+
+    /**
+     * Walk to the previous sibling. Please note that this does not work for
+     * the initial resource that was set with `init()`, as the parent
+     * resource is not known. This case can be solved with the help of
+     * `primaryParent()` and `secondaryParent()`.
+     *
+     * ```
+     * $walker->init($base);
+     * $walker->primaryParent();
+     * $walker->child($base->getId());
+     * $walker->previousSibling();
+     * ```
+     *
+     * @return Resource|null Returns null if there are no more siblings.
+     */
+    public function previousSibling(): ?Resource
+    {
+        if (empty($this->childrenStack)) {
+            return null;
+        }
+
+        $topStackIndex = count($this->childrenStack) - 1;
+        $children = $this->childrenStack[$topStackIndex];
+        $pointer = $this->childrenStackPointer[$topStackIndex] - 1;
+
+        if ($pointer < 0) {
+            return null;
+        }
+
+        //
+        $childLocation = $children[$pointer];
+        $child = $this->load($childLocation);
+
+        $this->childrenStackPointer[$topStackIndex] = $pointer;
+        $this->current = $child;
+        return $child;
+    }
+
+
+    /**
+     * Go up one level. This is only possible if the walker has already
+     * gone down one level. If the parent element is to be determined
+     * from an initial resource, `primaryParent` or `secondaryParent`
+     * must be used.
+     *
+     * @return Resource|null Returns null if the walker is already at the
+     * highest level.
+     */
+    public function up(): ?Resource
+    {
+        if ($this->current === null) {
+            throw new LogicException('No current resource set');
+        }
+
+        if (empty($this->parentPath)) {
+            return null;
+        }
+
+        $parent = array_pop($this->parentPath);
+
+        array_pop($this->childrenStack);
+        array_pop($this->childrenStackPointer);
+
+        $this->current = $parent;
+
+        return $this->current;
+    }
+
+    /**
+     * Goes down one level. And use the first child.
+     * This is only possible if the current resource also
+     * has children.
+     *
+     * @return Resource|null Returns null if the current resource
+     *  has no children.
+     * @throws LogicException If no current resource is set.
+     */
+    public function down(): ?Resource
+    {
+        if ($this->current === null) {
+            throw new LogicException('No current resource set');
+        }
+
+        $childrenLocations = $this->hierarchyLoader->getChildrenLocations(
+            $this->current
+        );
+        $children = array_values($childrenLocations);
+
+        if (empty($children)) {
+            return null;
+        }
+
+        $this->parentPath[] = $this->current;
+        $this->current = $this->load($children[0]);
+
+        $this->childrenStack[] = array_values($children);
+        $this->childrenStackPointer[count($this->childrenStack) - 1] = 0;
+
+        return $this->current;
+    }
+
+    /**
+     * Goes down one level like `down()`. However, the first child resource
+     * is not used here, instead `$childId` is used to specify which one is to
+     * be used child resource.
+     *
+     * @param string $childId The ID of the child resource to be used.
+     * @return Resource|null Returns null if the current resource has no
+     *  children or the child resource could not be found.
+     */
+    public function child(string $childId): ?Resource
+    {
+        if ($this->current === null) {
+            throw new LogicException('No current resource set');
+        }
+
+        $childrenLocations = $this->hierarchyLoader->getChildrenLocations(
+            $this->current
+        );
+
+        if (empty($childrenLocations)) {
+            return null;
+        }
+
+        $childPointer = array_search(
+            (int)$childId,
+            array_keys($childrenLocations),
+            true
+        );
+
+        if ($childPointer === false) {
+            return null;
+        }
+
+        $children = array_values($childrenLocations);
+
+        $this->parentPath[] = $this->current;
+        $this->current = $this->load($children[$childPointer]);
+
+        $this->childrenStack[] = array_values($children);
+        $this->childrenStackPointer[count($this->childrenStack) - 1] =
+            $childPointer;
+
+        return $this->current;
+    }
+
+
+    /**
+     * This method runs through the hierarchy downwards from the
+     * initial resource.
+     *
+     * @return Resource|null Returns `null` after the last resource in
+     * the hierarchy has been run through.
+     */
+    public function next(): ?Resource
+    {
+        if ($this->current === null) {
+            throw new LogicException('No current resource set');
+        }
+
+        $firstChildOfCurrent = $this->down();
+        if ($firstChildOfCurrent !== null) {
+            return $firstChildOfCurrent;
+        }
+
+        while (count($this->childrenStack) > 0) {
+            $child = $this->nextSibling();
+            if ($child !== null) {
+                return $child;
+            }
+            $this->up();
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Traverses the entire hierarchy downwards and calls the `$fn` method
+     * for each resource. Including the passed `$base` resource.
+     * In the method, `init($base)` is called, which resets the walker
+     * if necessary. Here `next()` is used to traverse the hierarchy.
+     *
+     * @param Resource $base The resource from which the hierarchy is to
+     *  be traversed.
+     * @param callable(Resource): void $fn The method to be called for each
+     *  resource.
+     */
+    public function walk(Resource $base, callable $fn): void
+    {
+        $this->init($base);
+        $fn($base);
+        while ($current = $this->next()) {
+            $fn($current);
+        }
+    }
+
+    private function load(string $location): Resource
+    {
+        return $this->hierarchyLoader->getResourceLoader()->load($location);
+    }
+}

--- a/src/ResourceHierarchyWalker.php
+++ b/src/ResourceHierarchyWalker.php
@@ -430,6 +430,6 @@ class ResourceHierarchyWalker
 
     private function load(string $location): Resource
     {
-        return $this->hierarchyLoader->getResourceLoader()->load($location);
+        return $this->hierarchyLoader->load($location);
     }
 }

--- a/test/Loader/CachedResourceLoaderTest.php
+++ b/test/Loader/CachedResourceLoaderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Resource\Test\Loader;
+
+use Atoolo\Resource\Loader\CachedResourceLoader;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceLoader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CachedResourceLoader::class)]
+class CachedResourceLoaderTest extends TestCase
+{
+    public function testLoad(): void
+    {
+        $resource = $this->createStub(Resource::class);
+        $loader = $this->createMock(ResourceLoader::class);
+        $loader->expects($this->once())
+            ->method('load')
+            ->with('test')
+            ->willReturn($resource);
+        $cachedLoader = new CachedResourceLoader($loader);
+        $cachedLoader->load('test'); // cache warmup
+
+        $this->assertEquals(
+            $resource,
+            $cachedLoader->load('test'),
+            'Resource should be loaded from cache'
+        );
+    }
+
+    public function testExistsUncached(): void
+    {
+        $loader = $this->createMock(ResourceLoader::class);
+        $loader->expects($this->once())
+            ->method('exists')
+            ->with('test')
+            ->willReturn(true);
+        $cachedLoader = new CachedResourceLoader($loader);
+
+        $this->assertTrue(
+            $cachedLoader->exists('test'),
+            'Resource should be test from cache'
+        );
+    }
+
+    public function testExistsCached(): void
+    {
+
+        $resource = $this->createStub(Resource::class);
+        $loader = $this->createMock(ResourceLoader::class);
+        $loader->expects($this->once())
+            ->method('load')
+            ->with('test')
+            ->willReturn($resource);
+        $loader->expects($this->exactly(0))
+            ->method('exists')
+            ->with('test')
+            ->willReturn(true);
+
+        $cachedLoader = new CachedResourceLoader($loader);
+        $cachedLoader->load('test'); // cache warmup
+
+        $this->assertTrue(
+            $cachedLoader->exists('test'),
+            'Resource should be test from cache'
+        );
+    }
+}

--- a/test/Loader/SiteKitResourceHierarchyLoaderTest.php
+++ b/test/Loader/SiteKitResourceHierarchyLoaderTest.php
@@ -297,35 +297,4 @@ class SiteKitResourceHierarchyLoaderTest extends TestCase
             'parent should be null'
         );
     }
-
-    public function testFindRecursive(): void
-    {
-        $resource = $this->hierarchyLoader->findRecursive(
-            '/a.php',
-            static function ($resource) {
-                return $resource->getId() === 'c';
-            }
-        );
-
-        $this->assertEquals(
-            'c',
-            $resource->getId(),
-            'unexpected resource'
-        );
-    }
-
-    public function testFindRecursiveNotFound(): void
-    {
-        $resource = $this->hierarchyLoader->findRecursive(
-            '/a.php',
-            static function ($resource) {
-                return $resource->getId() === 'not-existing';
-            }
-        );
-
-        $this->assertNull(
-            $resource,
-            'resource should be null'
-        );
-    }
 }

--- a/test/Loader/SiteKitResourceHierarchyLoaderTest.php
+++ b/test/Loader/SiteKitResourceHierarchyLoaderTest.php
@@ -177,7 +177,7 @@ class SiteKitResourceHierarchyLoaderTest extends TestCase
     {
         $resource = $this->hierarchyLoader->findRecursive(
             '/a.php',
-            static function ($path, $resource) {
+            static function ($resource) {
                 return $resource->getId() === 'c';
             }
         );
@@ -193,7 +193,7 @@ class SiteKitResourceHierarchyLoaderTest extends TestCase
     {
         $resource = $this->hierarchyLoader->findRecursive(
             '/a.php',
-            static function ($path, $resource) {
+            static function ($resource) {
                 return $resource->getId() === 'not-existing';
             }
         );

--- a/test/Loader/SiteKitResourceHierarchyLoaderTest.php
+++ b/test/Loader/SiteKitResourceHierarchyLoaderTest.php
@@ -9,6 +9,7 @@ use Atoolo\Resource\Loader\SiteKitResourceHierarchyLoader;
 use Atoolo\Resource\Resource;
 use Atoolo\Resource\ResourceLoader;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(SiteKitResourceHierarchyLoader::class)]
@@ -45,14 +46,38 @@ class SiteKitResourceHierarchyLoaderTest extends TestCase
         );
     }
 
-    public function testGetResourceLoader(): void
+    /**
+     * @throws Exception
+     */
+    public function testLoad(): void
     {
-        $class = new \ReflectionClass(SiteKitResourceHierarchyLoader::class);
-        $method = $class->getMethod('getResourceLoader');
-        $this->assertNotNull(
-            $method->invoke($this->hierarchyLoader),
-            'getResourceLoader should return the resource-loader'
+        $resourceLoader = $this->createMock(ResourceLoader::class);
+        $hierarchyLoader = new SiteKitResourceHierarchyLoader(
+            $resourceLoader,
+            'category'
         );
+
+        $resourceLoader->expects($this->once())
+            ->method('load');
+
+        $hierarchyLoader->load('/a.php');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testExists(): void
+    {
+        $resourceLoader = $this->createMock(ResourceLoader::class);
+        $hierarchyLoader = new SiteKitResourceHierarchyLoader(
+            $resourceLoader,
+            'category'
+        );
+
+        $resourceLoader->expects($this->once())
+            ->method('exists');
+
+        $hierarchyLoader->exists('/a.php');
     }
 
     public function testLoadPrimaryParentResourceWithoutParent(): void

--- a/test/Loader/SiteKitResourceHierarchyLoaderTest.php
+++ b/test/Loader/SiteKitResourceHierarchyLoaderTest.php
@@ -172,4 +172,35 @@ class SiteKitResourceHierarchyLoaderTest extends TestCase
         $this->expectException(InvalidResourceException::class);
         $this->hierarchyLoader->loadParent('/firstParentWithNonStringUrl.php');
     }
+
+    public function testFindRecursive(): void
+    {
+        $resource = $this->hierarchyLoader->findRecursive(
+            '/a.php',
+            static function ($path, $resource) {
+                return $resource->getId() === 'c';
+            }
+        );
+
+        $this->assertEquals(
+            'c',
+            $resource->getId(),
+            'unexpected resource'
+        );
+    }
+
+    public function testFindRecursiveNotFound(): void
+    {
+        $resource = $this->hierarchyLoader->findRecursive(
+            '/a.php',
+            static function ($path, $resource) {
+                return $resource->getId() === 'not-existing';
+            }
+        );
+
+        $this->assertNull(
+            $resource,
+            'resource should be null'
+        );
+    }
 }

--- a/test/ResourceHierarchyFinderTest.php
+++ b/test/ResourceHierarchyFinderTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Resource\Test;
+
+use Atoolo\Resource\Loader\SiteKitResourceHierarchyLoader;
+use Atoolo\Resource\ResourceHierarchyFinder;
+use Atoolo\Resource\ResourceLoader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResourceHierarchyFinder::class)]
+class ResourceHierarchyFinderTest extends TestCase
+{
+    private ResourceLoader $loader;
+
+    private ResourceHierarchyFinder $finder;
+
+    public function setUp(): void
+    {
+        $resourceBaseDir = realpath(
+            __DIR__ . '/resources/' .
+            'ResourceHierarchyFinder'
+        );
+        $this->loader = $this->createStub(
+            ResourceLoader::class
+        );
+        $this->loader->method('load')
+            ->willReturnCallback(static function ($location) use (
+                $resourceBaseDir
+            ) {
+                return include $resourceBaseDir . $location;
+            });
+
+        $hierarchyLoader = new SiteKitResourceHierarchyLoader(
+            $this->loader,
+            'category'
+        );
+        $this->finder = new ResourceHierarchyFinder(
+            $hierarchyLoader
+        );
+    }
+
+    public function testFindFirst(): void
+    {
+        $resource = $this->finder->findFirst(
+            '/a.php',
+            static function ($resource) {
+                return $resource->getId() === 'c';
+            }
+        );
+
+        $this->assertEquals(
+            'c',
+            $resource->getId(),
+            'Resource c should be found'
+        );
+    }
+
+    public function testFindFirstFindBase(): void
+    {
+        $resource = $this->finder->findFirst(
+            '/a.php',
+            static function ($resource) {
+                return $resource->getId() === 'a';
+            }
+        );
+
+        $this->assertEquals(
+            'a',
+            $resource->getId(),
+            'Resource a should be found'
+        );
+    }
+
+    public function testFindFirstNotFound(): void
+    {
+        $resource = $this->finder->findFirst(
+            '/a.php',
+            static function ($resource) {
+                return $resource->getId() === 'x';
+            }
+        );
+
+        $this->assertNull(
+            $resource,
+            'Resource should not be found'
+        );
+    }
+}

--- a/test/ResourceHierarchyWalkerTest.php
+++ b/test/ResourceHierarchyWalkerTest.php
@@ -1,0 +1,438 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\Resource\Test;
+
+use Atoolo\Resource\Loader\SiteKitResourceHierarchyLoader;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceHierarchyLoader;
+use Atoolo\Resource\ResourceHierarchyWalker;
+use Atoolo\Resource\ResourceLoader;
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResourceHierarchyWalker::class)]
+class ResourceHierarchyWalkerTest extends TestCase
+{
+    private ResourceLoader $loader;
+
+    private ResourceHierarchyWalker $walker;
+
+    /**
+     * @throws Exception
+     */
+    public function setUp(): void
+    {
+        $resourceBaseDir = realpath(
+            __DIR__ . '/resources/' .
+            'ResourceHierarchyWalker'
+        );
+        $this->loader = $this->createStub(
+            ResourceLoader::class
+        );
+        $this->loader->method('load')
+            ->willReturnCallback(static function ($location) use (
+                $resourceBaseDir
+            ) {
+                return include $resourceBaseDir . $location;
+            });
+
+        $hierarchyLoader = new SiteKitResourceHierarchyLoader(
+            $this->loader,
+            'category'
+        );
+
+        $this->walker = new ResourceHierarchyWalker(
+            $hierarchyLoader
+        );
+    }
+
+    public function testInitWithLocation(): void
+    {
+        $this->walker->init('/1.php');
+
+        $this->assertEquals(
+            '1',
+            $this->walker->getCurrent()->getId(),
+            'base resource should be found'
+        );
+    }
+
+    public function testGetCurrentWithoutInit(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->walker->getCurrent();
+    }
+
+    public function testInitWithResource(): void
+    {
+        $base = $this->loader->load('/1.php');
+        $this->walker->init($base);
+
+        $this->assertEquals(
+            '1',
+            $this->walker->getCurrent()->getId(),
+            'base resource should be found'
+        );
+    }
+
+    public function testPrimaryParent(): void
+    {
+        $base = $this->loader->load('/1/1.php');
+        $this->walker->init($base);
+
+        $this->walker->primaryParent();
+
+        $this->assertEquals(
+            '1',
+            $this->walker->getCurrent()->getId(),
+            'unexpected primary parent'
+        );
+    }
+
+    public function testPrimaryParentWithoutInit(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->walker->primaryParent();
+    }
+
+    public function testPrimaryParentOfRoot(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+
+        $this->assertNull(
+            $this->walker->primaryParent(),
+            'root should not have a primary parent'
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testPrimaryParentWithoutPrimaryParent(): void
+    {
+        $hierarchyLoader = $this->createStub(
+            ResourceHierarchyLoader::class
+        );
+        $hierarchyLoader->method('getPrimaryParentLocation')
+            ->willReturn(null);
+
+        $walker = new ResourceHierarchyWalker(
+            $hierarchyLoader
+        );
+        $base = $this->createStub(Resource::class);
+
+        $walker->init($base);
+
+        $this->assertNull(
+            $walker->primaryParent(),
+            'root should not have a primary parent'
+        );
+    }
+
+    public function testParent(): void
+    {
+        $base = $this->loader->load('/1/1.php');
+        $this->walker->init($base);
+
+        $this->walker->parent('2');
+
+        $this->assertEquals(
+            '2',
+            $this->walker->getCurrent()->getId(),
+            'unexpected secondary parent'
+        );
+    }
+
+    public function testParentWithoutInit(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->walker->parent('1');
+    }
+
+    public function testParentOfRoot(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+
+        $this->assertNull(
+            $this->walker->parent('1'),
+            'root should not have a primary parent'
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testParentWithoutPrimaryParent(): void
+    {
+        $hierarchyLoader = $this->createStub(
+            ResourceHierarchyLoader::class
+        );
+        $hierarchyLoader->method('getPrimaryParentLocation')
+            ->willReturn(null);
+
+        $walker = new ResourceHierarchyWalker(
+            $hierarchyLoader
+        );
+        $base = $this->createStub(Resource::class);
+
+        $walker->init($base);
+
+        $this->assertNull(
+            $walker->parent('1'),
+            'root should not have a primary parent'
+        );
+    }
+
+    public function testGetLevel(): void
+    {
+        $base = $this->loader->load('/1.php');
+        $this->walker->init($base);
+        $this->walker->down();
+
+        $this->assertEquals(
+            1,
+            $this->walker->getLevel(),
+            'level should be 1'
+        );
+    }
+
+    public function testGetPath(): void
+    {
+        $base = $this->loader->load('/1.php');
+        $this->walker->init($base);
+        $this->walker->down();
+
+        $expected = ['1', '1-1'];
+
+        $this->assertEquals(
+            $expected,
+            array_map(
+                static fn($resource) => $resource->getId(),
+                $this->walker->getPath()
+            ),
+            'unexpected path'
+        );
+    }
+
+    public function testGetPathWithoutInit(): void
+    {
+        $this->assertEmpty(
+            $this->walker->getPath(),
+            'path should be empty'
+        );
+    }
+
+    public function testNextSibling(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+        $this->walker->down();
+        $this->walker->nextSibling();
+
+        $this->assertEquals(
+            '2',
+            $this->walker->getCurrent()->getId(),
+            'unexpected sibling'
+        );
+    }
+
+    public function testNextSiblingWithoutInit(): void
+    {
+        $this->assertNull(
+            $this->walker->nextSibling(),
+            'nextSibling should be null'
+        );
+    }
+
+    public function testPreviousSibling(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+        $this->walker->down();
+        $this->walker->nextSibling();
+        $this->walker->previousSibling();
+
+        $this->assertEquals(
+            '1',
+            $this->walker->getCurrent()->getId(),
+            'unexpected sibling'
+        );
+    }
+
+    public function testPreviousSiblingWithoutInit(): void
+    {
+        $this->assertNull(
+            $this->walker->previousSibling(),
+            'previousSibling should be null'
+        );
+    }
+
+    public function testPreviousSiblingWithFirstChild(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+        $this->walker->down();
+        $this->walker->previousSibling();
+
+        $this->assertNull(
+            $this->walker->previousSibling(),
+            'previousSibling should be null'
+        );
+    }
+
+    public function testUp(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+        $this->walker->down();
+        $this->walker->up();
+
+        $this->assertEquals(
+            'root',
+            $this->walker->getCurrent()->getId(),
+            'unexpected current resource'
+        );
+    }
+
+    public function testUpWithoutInit(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->walker->up();
+    }
+
+    public function testUpForFirstLevel(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+
+        $this->assertNull(
+            $this->walker->up(),
+            'up should be null'
+        );
+    }
+
+    public function testDown(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+        $this->walker->down();
+
+        $this->assertEquals(
+            '1',
+            $this->walker->getCurrent()->getId(),
+            'unexpected current resource'
+        );
+    }
+
+    public function testDownWithoutInit(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->walker->down();
+    }
+
+    public function testChild(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+        $this->walker->child('2');
+
+        $this->assertEquals(
+            '2',
+            $this->walker->getCurrent()->getId(),
+            'unexpected current resource'
+        );
+    }
+
+    public function testChildNotFound(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+
+        $this->assertNull(
+            $this->walker->child('7'),
+            'child should be null'
+        );
+    }
+
+    public function testChildWithoutInit(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->walker->child('2');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testChildWithoutChildren(): void
+    {
+        $hierarchyLoader = $this->createStub(
+            ResourceHierarchyLoader::class
+        );
+        $hierarchyLoader->method('getChildrenLocations')
+            ->willReturn([]);
+
+        $walker = new ResourceHierarchyWalker(
+            $hierarchyLoader
+        );
+        $base = $this->createStub(Resource::class);
+
+        $walker->init($base);
+
+        $this->assertNull(
+            $walker->child('1'),
+            'child should be null'
+        );
+    }
+
+    public function testNext(): void
+    {
+        $base = $this->loader->load('/root.php');
+        $this->walker->init($base);
+        $this->walker->next();
+
+        $this->assertEquals(
+            '1',
+            $this->walker->getCurrent()->getId(),
+            'unexpected current resource'
+        );
+    }
+
+    public function testNextWithoutInit(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->walker->next();
+    }
+
+    public function testWalk(): void
+    {
+        $root = $this->loader->load('/root.php');
+        $this->walker->init($root);
+
+        $idList = [];
+        $this->walker->walk($root, function ($resource) use (&$idList) {
+            $idList[] = $resource->getId();
+        });
+
+        $expected = [
+            'root',
+            '1',
+            '1-1',
+            '1-1-1',
+            '1-1-1-1',
+            '2',
+            '2-1',
+            '2-2',
+        ];
+        $this->assertEquals(
+            $expected,
+            $idList,
+            'unexpected id list'
+        );
+    }
+}

--- a/test/resources/Loader/SiteKitResourceHierarchyLoader/a.php
+++ b/test/resources/Loader/SiteKitResourceHierarchyLoader/a.php
@@ -7,5 +7,18 @@ return new \Atoolo\Resource\Resource(
     'a',
     'a',
     '',
-    []
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'children' => [
+                        'b' => [
+                            'id' => 'b',
+                            'url' => '/b.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
 );

--- a/test/resources/ResourceHierarchyFinder/a.php
+++ b/test/resources/ResourceHierarchyFinder/a.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/a.php',
+    'a',
+    'a',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'children' => [
+                        'b' => [
+                            'id' => 'b',
+                            'url' => '/b.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+);

--- a/test/resources/ResourceHierarchyFinder/b.php
+++ b/test/resources/ResourceHierarchyFinder/b.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/b.php',
+    'b',
+    'b',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'parents' => [
+                        'a' => [
+                            'url' => '/a.php'
+                        ]
+                    ],
+                    'children' => [
+                        'c' => [
+                            'id' => 'c',
+                            'url' => '/c.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+);

--- a/test/resources/ResourceHierarchyFinder/c.php
+++ b/test/resources/ResourceHierarchyFinder/c.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/c.php',
+    'c',
+    'c',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'parents' => [
+                        'b' => [
+                            'isPrimary' => true,
+                            'url' => '/b.php'
+                        ],
+                        'a' => [
+                            'url' => '/a.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+);

--- a/test/resources/ResourceHierarchyWalker/1.php
+++ b/test/resources/ResourceHierarchyWalker/1.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/1.php',
+    '1',
+    '1',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'parents' => [
+                        'root' => [
+                            'url' => '/root.php'
+                        ]
+                    ],
+                    'children' => [
+                        '1-1' => [
+                            'id' => '1-1',
+                            'url' => '/1/1.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+);

--- a/test/resources/ResourceHierarchyWalker/1/1.php
+++ b/test/resources/ResourceHierarchyWalker/1/1.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/1/1.php',
+    '1-1',
+    '1-1',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'parents' => [
+                        '1' => [
+                            'url' => '/1.php'
+                        ],
+                        '2' => [
+                            'url' => '/2.php'
+                        ]
+                    ],
+                    'children' => [
+                        '1-1-1' => [
+                            'id' => '1-1-1',
+                            'url' => '/1/1/1.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+);

--- a/test/resources/ResourceHierarchyWalker/1/1/1.php
+++ b/test/resources/ResourceHierarchyWalker/1/1/1.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/1/1/1.php',
+    '1-1-1',
+    '1-1-1',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'parents' => [
+                        '1-1' => [
+                            'url' => '/1/1.php'
+                        ]
+                    ],
+                    'children' => [
+                        '1-1-1-1' => [
+                            'id' => '1-1-1-1',
+                            'url' => '/1/1/1/1.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+);

--- a/test/resources/ResourceHierarchyWalker/1/1/1/1.php
+++ b/test/resources/ResourceHierarchyWalker/1/1/1/1.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/1-1-1-1.php',
+    '1-1-1-1',
+    '1-1-1-1',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'parents' => [
+                        '1-1-1' => [
+                            'url' => '/1/1/1.php'
+                        ]
+                    ],
+                ]
+            ]
+        ]
+    ]
+);

--- a/test/resources/ResourceHierarchyWalker/2.php
+++ b/test/resources/ResourceHierarchyWalker/2.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/2.php',
+    '2',
+    '2',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'parents' => [
+                        'root' => [
+                            'url' => '/root.php'
+                        ]
+                    ],
+                    'children' => [
+                        '2-1' => [
+                            'id' => '2-1',
+                            'url' => '/2/1.php'
+                        ],
+                        '2-2' => [
+                            'id' => '2-2',
+                            'url' => '/2/2.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+);

--- a/test/resources/ResourceHierarchyWalker/2/1.php
+++ b/test/resources/ResourceHierarchyWalker/2/1.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/2/1.php',
+    '2-1',
+    '2-1',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'parents' => [
+                        '2' => [
+                            'url' => '/2.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+);

--- a/test/resources/ResourceHierarchyWalker/2/2.php
+++ b/test/resources/ResourceHierarchyWalker/2/2.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/2/2.php',
+    '2-2',
+    '2-2',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'parents' => [
+                        '2' => [
+                            'url' => '/2.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+);

--- a/test/resources/ResourceHierarchyWalker/root.php
+++ b/test/resources/ResourceHierarchyWalker/root.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+return new \Atoolo\Resource\Resource(
+    '/root.php',
+    'root',
+    'root',
+    '',
+    [
+        'base' => [
+            'trees' => [
+                'category' => [
+                    'children' => [
+                        '1 1' => [
+                            'id' => '1',
+                            'url' => '/1.php'
+                        ],
+                        '2' => [
+                            'id' => '2',
+                            'url' => '/2.php'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+);


### PR DESCRIPTION
To be able to find resources in the resource hierarchy according to certain criteria, a `findResource` method is required.

If this method is used intensively, the resource should not have to be reloaded every time. For this reason, a CachedResourceLoader is also provided that can cache resources that have already been loaded.